### PR TITLE
Wrote a model debugger

### DIFF
--- a/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
@@ -76,6 +76,7 @@ public class TEApp extends PApplet implements LXPlugin  {
     lx.registry.addPattern(Bubbles.class);
     lx.registry.addPattern(Checkers.class);
     lx.registry.addPattern(EdgeRunner.class);
+    lx.registry.addPattern(ModelDebugger.class);
     lx.registry.addPattern(SimpleSolidEdgePattern.class);
     lx.registry.addPattern(SimpleSolidPanelPattern.class);
     lx.registry.addPattern(Pulse.class);

--- a/LXStudio-IDE/src/main/java/titanicsend/pattern/mike/ModelDebugger.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/pattern/mike/ModelDebugger.java
@@ -1,0 +1,133 @@
+package titanicsend.pattern.mike;
+
+import java.util.*;
+
+import heronarts.lx.LX;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.*;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.device.UIDevice;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+import heronarts.p4lx.ui.UI2dComponent;
+import heronarts.p4lx.ui.UI2dContainer;
+import heronarts.p4lx.ui.component.UITextBox;
+import titanicsend.pattern.TEPattern;
+
+public class ModelDebugger extends TEPattern implements UIDeviceControls<ModelDebugger> {
+  public enum ObjectType {
+    VERTEX("Vertex"),
+    EDGE("Edge"),
+    PANEL("Panel"),
+    LASER("Laser");
+
+    public final String label;
+
+    ObjectType(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  }
+
+  public final EnumParameter<ObjectType> objectType =
+          new EnumParameter<ObjectType>("Object Type", ObjectType.VERTEX)
+                  .setDescription("Which type of object to light up");
+
+  public final DiscreteParameter pointIndex =
+          new DiscreteParameter("Index", -1, 1000)
+                  .setDescription("Pixel within the selected object to light up (-1 for all)");
+
+  public final StringParameter objectId =
+          new StringParameter("ID")
+                  .setDescription("ID of the object to light up (blank for all)");
+
+  private UI2dComponent idErrLabel;
+  private UI2dComponent pointErrLabel;
+
+  public ModelDebugger(LX lx) {
+    super(lx);
+  }
+
+  @Override
+  public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, ModelDebugger pattern) {
+    uiDevice.setLayout(UI2dContainer.Layout.VERTICAL);
+    uiDevice.setChildSpacing(6);
+    uiDevice.setContentWidth(COL_WIDTH);
+
+    uiDevice.addChildren(
+            newDropMenu(objectType),
+            controlLabel(ui, "ID"),
+            new UITextBox(0, 0, COL_WIDTH, 16).setParameter(objectId),
+            controlLabel(ui, "Point"),
+            newIntegerBox(pointIndex),
+            this.idErrLabel = controlLabel(ui, "Bad ID"),
+            this.pointErrLabel = controlLabel(ui, "Bad point")
+    );
+
+    this.objectType.addListener(this::repaint);
+    this.objectId.addListener(this::repaint);
+    this.pointIndex.addListener(this::repaint);
+  }
+
+  public void repaint(LXParameter unused) {
+    for (LXPoint point : this.model.points) {
+      colors[point.index] = 0; // Transparent
+    }
+    List<LXModel> subModels = new ArrayList<>();
+    String idStr = this.objectId.getString().trim().toUpperCase();
+    boolean getAll = idStr.equals("");
+
+    this.idErrLabel.setVisible(false);
+
+    switch (this.objectType.getEnum()) {
+      case VERTEX:
+        // TODO: implement
+        break;
+      case EDGE:
+        if (getAll)
+          subModels.addAll(this.model.edgesById.values());
+        else if (this.model.edgesById.containsKey(idStr))
+          subModels.add(this.model.edgesById.get(idStr));
+        else
+          this.idErrLabel.setVisible(true);
+        break;
+      case PANEL:
+        if (getAll)
+          subModels.addAll(this.model.panelsById.values());
+        else if (this.model.panelsById.containsKey(idStr))
+          subModels.add(this.model.panelsById.get(idStr));
+        else
+          this.idErrLabel.setVisible(true);
+        break;
+      case LASER:
+        // TODO: Implement
+        break;
+      default:
+          throw new Error("huh?");
+    }
+
+    // If no submodels, don't print error about invalid points.
+    // If there are submodels, turn on the error for now and see if it gets turned off.
+    boolean pointErr = !subModels.isEmpty();
+
+    int pi = this.pointIndex.getValuei();
+    for (LXModel subModel : subModels) {
+      for (int i = 0; i < subModel.points.length; i++) {
+        if (pi < 0 || pi == i) {
+          pointErr = false;
+          LXPoint point = subModel.points[i];
+          colors[point.index] = LXColor.WHITE;
+        }
+      }
+    }
+    this.pointErrLabel.setVisible(pointErr);
+  }
+
+  public void run(double deltaMs) {
+  }
+}

--- a/LXStudio-IDE/src/main/java/titanicsend/pattern/mike/ModelDebugger.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/pattern/mike/ModelDebugger.java
@@ -59,15 +59,19 @@ public class ModelDebugger extends TEPattern implements UIDeviceControls<ModelDe
     uiDevice.setChildSpacing(6);
     uiDevice.setContentWidth(COL_WIDTH);
 
+    UITextBox tb;
+
     uiDevice.addChildren(
             newDropMenu(objectType),
             controlLabel(ui, "ID"),
-            new UITextBox(0, 0, COL_WIDTH, 16).setParameter(objectId),
+            tb = new UITextBox(0, 0, COL_WIDTH, 16).setParameter(objectId),
             controlLabel(ui, "Point"),
             newIntegerBox(pointIndex),
             this.idErrLabel = controlLabel(ui, "Bad ID"),
             this.pointErrLabel = controlLabel(ui, "Bad point")
     );
+
+    tb.setEmptyValueAllowed(true);
 
     this.objectType.addListener(this::repaint);
     this.objectId.addListener(this::repaint);


### PR DESCRIPTION
You can use it to turn on any particular Edge or Panel by typing its ID, or any particular point in that object (or the same point number in all objects)

![model-debugger](https://user-images.githubusercontent.com/281755/153664339-7156dedf-977d-45b1-a911-0ff196f7d8d1.gif)

Vertexes and Lasers not yet implemented. One problem I'm running into is that even though I tried to give pointIndex a min-value of -1, it refuses to let me set it to that value (except by creating a new ModelDebugger, which uses this as the default). It won't let me type a minus, and if I'm at 0 and press down, it stays at 0.

Similarly, I'm using a blank value in the ID field to represent "all objects of this type", but the textbox won't let me set it to that. If I try to set it to the empty string, or even a string containing all whitespace, it rejects that input and returns to the previously-selected value. If there's no easy way to disable this behavior, I'll just have to use "*" as my wildcard.