### PR TITLE
Add SimpleScreen and ResizableScreen patterns

### DIFF
--- a/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
@@ -78,6 +78,7 @@ public class TEApp extends PApplet implements LXPlugin  {
     lx.registry.addPattern(BasicRainbowPattern.class);
     lx.registry.addPattern(Bounce.class);
     lx.registry.addPattern(BrightScreen.class);
+    lx.registry.addPattern(ResizeableScreen.class);
     lx.registry.addPattern(Bubbles.class);
     lx.registry.addPattern(Checkers.class);
     lx.registry.addPattern(EdgeRunner.class);

--- a/LXStudio-IDE/src/main/java/titanicsend/pattern/alex/ResizeableScreen.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/pattern/alex/ResizeableScreen.java
@@ -1,0 +1,122 @@
+package titanicsend.pattern.alex;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.studio.LXStudio;
+import heronarts.p4lx.ui.component.UIButton;
+import heronarts.lx.studio.ui.device.UIDevice;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+import heronarts.p4lx.ui.UI2dContainer;
+
+import titanicsend.pattern.TEPattern;
+import titanicsend.util.SimpleScreen;
+
+import java.util.ArrayList;
+import java.util.*;
+
+@LXCategory("Testahedron")
+// A ResizeableScreen is a dynamically-resized rectangular screen that maps pixels without an area
+// defined by the caller.
+// TODO: right now, we just color all pixels white. Soon, we should take a data array and color array
+// to dynamically color each point and re-render the canvas whenever these points come in.
+public class ResizeableScreen extends TEPattern implements UIDeviceControls<ResizeableScreen> {
+    private SimpleScreen screen;
+
+    // Technically, we do have doubles, but the values are in microns, so if you really need a fraction
+    // of a micron, you can figure out how to do this with BoundedParameters instead.
+    // Note: extra +1 is because DiscreteParameters have an _exclusive_ bound on the upper end.
+    private int roundedLowerYLimit = (int)this.model.boundaryPoints.minYBoundaryPoint.y;
+    private int roundedUpperYLimit = (int)this.model.boundaryPoints.maxYBoundaryPoint.y + 1;
+    private int roundedLowerZLimit = (int)this.model.boundaryPoints.minZBoundaryPoint.z;
+    private int roundedUpperZLimit = (int)this.model.boundaryPoints.maxZBoundaryPoint.z + 1;
+
+    // The extra +1 on the ends is because DiscreteParameter bounds are exclusive at the top end.
+    public final DiscreteParameter lowerYBoundParam =
+            new DiscreteParameter("Lower Y Bound", this.roundedLowerYLimit / 2, this.roundedLowerYLimit, this.roundedUpperYLimit)
+                    .setDescription("Lower boundary for the Y coordinate of the screen");
+    public final DiscreteParameter upperYBoundParam =
+            new DiscreteParameter("Upper Y Bound", this.roundedUpperYLimit / 2, this.roundedLowerYLimit, this.roundedUpperYLimit)
+                    .setDescription("Upper boundary for the Y coordinate of the screen");
+    public final DiscreteParameter lowerZBoundParam =
+            new DiscreteParameter("Lower Z Bound", this.roundedLowerZLimit / 2, this.roundedLowerZLimit, this.roundedUpperZLimit)
+                    .setDescription("Lower boundary for the Z coordinate of the screen");
+    public final DiscreteParameter upperZBoundParam =
+            new DiscreteParameter("Upper Z Bound", this.roundedUpperZLimit / 2, this.roundedLowerZLimit, this.roundedUpperZLimit)
+                    .setDescription("Upper boundary for the Z coordinate of the screen");
+    public BooleanParameter doubleSidedParam =
+            new BooleanParameter("Double Sided?")
+                    .setDescription("Toggle whether screen is drawn on both sides of the car or not (Default false)")
+                    .setValue(false);
+
+    private void toggleDoubleSided() {
+        this.doubleSidedParam.setValue(!this.doubleSidedParam.getValueb());
+    }
+    
+    @Override
+    public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, ResizeableScreen pattern) {
+        uiDevice.setLayout(UI2dContainer.Layout.VERTICAL);
+        uiDevice.setChildSpacing(5);
+        uiDevice.setContentWidth(3 * COL_WIDTH);
+
+        uiDevice.addChildren(
+            controlLabel(ui, "Lower Y Bound"),
+            newIntegerBox(this.lowerYBoundParam),
+            controlLabel(ui, "Upper Y Bound"),
+            newIntegerBox(this.upperYBoundParam),
+            controlLabel(ui, "Lower Z Bound"),
+            newIntegerBox(this.lowerZBoundParam), 
+            controlLabel(ui, "Upper Z Bound"),
+            newIntegerBox(this.upperZBoundParam),
+            new UIButton(0, 0, 2 * COL_WIDTH, 20) {
+                @Override
+                public void onToggle(boolean unused) {
+                    toggleDoubleSided();
+                }
+            }
+            .setLabel("Double Sided?"));
+        this.lowerYBoundParam.addListener(this::repaint);
+        this.upperYBoundParam.addListener(this::repaint);
+        this.lowerZBoundParam.addListener(this::repaint);
+        this.upperZBoundParam.addListener(this::repaint);
+        this.doubleSidedParam.addListener(this::repaint);
+    }
+
+    private void paint(double deltaMs) {
+        for (LXPoint point : this.screen.screenGrid) {
+            colors[point.index] = LXColor.WHITE;
+        }
+    }
+
+    private void sizeAndPaintScreen() {
+        ArrayList<LXPoint> pointsList = new ArrayList<>(Arrays.asList(this.model.points));
+        this.screen = new SimpleScreen(
+            pointsList,
+            this.lowerYBoundParam.getValuei(),
+            this.upperYBoundParam.getValuei(),
+            this.lowerZBoundParam.getValuei(),
+            this.upperZBoundParam.getValuei(),
+            this.doubleSidedParam.getValueb());
+        LX.log(String.format("%d points in screen:", this.screen.screenGrid.size()));
+
+        this.paint(0);
+    }
+
+    public void repaint(LXParameter unused) {
+        this.clearPixels();
+        this.sizeAndPaintScreen();
+    }
+
+    public ResizeableScreen(LX lx) {
+        super(lx);
+        this.sizeAndPaintScreen();
+    }
+
+    public void run(double deltaMs) {
+        this.paint(deltaMs);
+    }
+}

--- a/LXStudio-IDE/src/main/java/titanicsend/util/SimpleScreen.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/util/SimpleScreen.java
@@ -1,0 +1,35 @@
+package titanicsend.model;
+
+import heronarts.lx.model.LXPoint;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+
+// A SimpleScreen is a two-dimensional approximation of a monitor or TV screen against
+// the side of Titanic's End.
+// TODO: allow arbitrary height/width to the screen
+// TODO: allow arbitrary positioning of this screen
+public class SimpleScreen {
+    private static final int SCREEN_WIDTH = 100;
+    private static final int SCREEN_HEIGHT = 25;
+
+    public ArrayList<LXPoint> screenGrid;
+
+    // buildScreenGrid transforms 3-dimensional LXPoints (x,y,z) into points along a screen
+    // with only an x and a theta property.
+    private void buildScreenGrid(ArrayList<LXPoint> pointsList, double zLowerBound, double zUpperBound, double yLowerBound, double yUpperBound) {
+        ArrayList<LXPoint> screenGrid = new ArrayList<LXPoint>(SCREEN_WIDTH);
+
+        for (LXPoint point : pointsList) {
+            if ((point.z <= zUpperBound && point.z >= zLowerBound) && (point.y <= yUpperBound && point.y >= yLowerBound)) {
+                screenGrid.add(point);
+            }
+        }
+        this.screenGrid = screenGrid;
+    }
+
+    public SimpleScreen(ArrayList<LXPoint> pointsList, double zLowerBound, double zUpperBound, double yLowerBound, double yUpperBound) {
+
+        buildScreenGrid(pointsList, zLowerBound, zUpperBound, yLowerBound, yUpperBound);
+    }
+}

--- a/LXStudio-IDE/src/main/java/titanicsend/util/SimpleScreen.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/util/SimpleScreen.java
@@ -1,5 +1,6 @@
-package titanicsend.model;
+package titanicsend.util;
 
+import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
 
 import java.util.ArrayList;
@@ -7,29 +8,48 @@ import java.util.Comparator;
 
 // A SimpleScreen is a two-dimensional approximation of a monitor or TV screen against
 // the side of Titanic's End.
-// TODO: allow arbitrary height/width to the screen
+// TODO: allow drawing against any dimensions. Currently, we flatten the X axis (the axis
+// the lasers will blast the crowd through) and preserve the Y and Z coordinates.
 // TODO: allow arbitrary positioning of this screen
 public class SimpleScreen {
-    private static final int SCREEN_WIDTH = 100;
-    private static final int SCREEN_HEIGHT = 25;
-
     public ArrayList<LXPoint> screenGrid;
 
-    // buildScreenGrid transforms 3-dimensional LXPoints (x,y,z) into points along a screen
-    // with only an x and a theta property.
-    private void buildScreenGrid(ArrayList<LXPoint> pointsList, double zLowerBound, double zUpperBound, double yLowerBound, double yUpperBound) {
-        ArrayList<LXPoint> screenGrid = new ArrayList<LXPoint>(SCREEN_WIDTH);
+    private void buildScreenGrid(
+        ArrayList<LXPoint> pointsList,
+        int yLowerBound,
+        int yUpperBound,
+        int zLowerBound,
+        int zUpperBound,
+        boolean doubleSided) {
+        LX.log("Inside SimpleScreen.buildScreenGrid");
+        LX.log(String.format("  Lower Y: %d", yLowerBound));
+        LX.log(String.format("  Upper Y: %d", yUpperBound));
+        LX.log(String.format("  Lower Z: %d", zLowerBound));
+        LX.log(String.format("  Upper Z: %d", zUpperBound));
+
+        ArrayList<LXPoint> screenGrid = new ArrayList<LXPoint>();
 
         for (LXPoint point : pointsList) {
-            if ((point.z <= zUpperBound && point.z >= zLowerBound) && (point.y <= yUpperBound && point.y >= yLowerBound)) {
-                screenGrid.add(point);
+            if (
+                (point.z <= zUpperBound && point.z >= zLowerBound) &&
+                (point.y <= yUpperBound && point.y >= yLowerBound)) {
+                if (doubleSided) {
+                    screenGrid.add(point);
+                } else if (point.x >= 0) {
+                    screenGrid.add(point);
+                }
             }
         }
         this.screenGrid = screenGrid;
     }
 
-    public SimpleScreen(ArrayList<LXPoint> pointsList, double zLowerBound, double zUpperBound, double yLowerBound, double yUpperBound) {
-
-        buildScreenGrid(pointsList, zLowerBound, zUpperBound, yLowerBound, yUpperBound);
+    public SimpleScreen(
+        ArrayList<LXPoint> pointsList,
+        int yLowerBound,
+        int yUpperBound,
+        int zLowerBound,
+        int zUpperBound,
+        boolean doubleSided) {
+        buildScreenGrid(pointsList, yLowerBound, yUpperBound, zLowerBound, zUpperBound, doubleSided);
     }
 }


### PR DESCRIPTION
This is the first step in building a reusable screen projection.
The goal here is to essentially flatten the 3D sides of the model into 2D
by removing the X axis component. (the direction lasers blast the crowd
in the face with)

Now that we have these base components, we can extend them to:

- Allow dynamic data to drive color and pixel activation (right now it's static white)
  - This could be an image, a video file, etc. Just a 2D array of positions with RGB values at each
- Compose multiple panels on the car simultaneously
- Constrain a full-car effect into a local area