### PR TITLE
Added HandTracker to show position received from OSC Messages

### DIFF
--- a/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/app/TEApp.java
@@ -33,6 +33,7 @@ import titanicsend.pattern.jeff.*;
 import titanicsend.pattern.tmc.*;
 import titanicsend.pattern.tom.*;
 import titanicsend.pattern.mike.*;
+import titanicsend.pattern.cesar.*;
 
 public class TEApp extends PApplet implements LXPlugin  {
   private TEWholeModel model;
@@ -92,6 +93,7 @@ public class TEApp extends PApplet implements LXPlugin  {
     lx.registry.addPattern(SimpleSolidEdgePattern.class);
     lx.registry.addPattern(SimpleSolidPanelPattern.class);
     lx.registry.addPattern(Pulse.class);
+    lx.registry.addPattern(HandTracker.class);
     lx.registry.addEffect(titanicsend.effect.BasicEffect.class);
 
     int myGigglePixelID = 73;  // Looks like "TE"

--- a/LXStudio-IDE/src/main/java/titanicsend/pattern/cesar/HandTracker.java
+++ b/LXStudio-IDE/src/main/java/titanicsend/pattern/cesar/HandTracker.java
@@ -1,0 +1,76 @@
+package titanicsend.pattern.cesar;
+
+import heronarts.lx.LX;
+import heronarts.lx.color.ColorParameter;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.parameter.StringParameter;
+import titanicsend.model.TEPanelModel;
+import titanicsend.pattern.TEPattern;
+import titanicsend.util.TEColorGroupPattern;
+
+public class HandTracker extends TEColorGroupPattern {
+
+    public final ColorParameter color =
+            new ColorParameter("Color")
+                    .setDescription("Color of the pattern");
+
+    public final CompoundParameter targetY =
+            new CompoundParameter("Target height", 5, 0, 100)
+                    .setDescription("Target height from ground");
+    public final CompoundParameter targetZ =
+            new CompoundParameter("Target position", 5, 0, 100)
+                    .setDescription("Target position left and right");
+
+    public final StringParameter indexTip =
+            new StringParameter("Index Tip", "10,50")
+                    .setDescription("Following a finger tip (X, Z) 0-100 like '(10,50)'");
+
+    public HandTracker(LX lx) {
+        this(lx, LXColor.RED);
+    }
+
+    public HandTracker(LX lx, int color) {
+        super(lx, new String[]{"ColorA"});
+        this.color.setColor(color);
+        addParameter("color", this.color);
+        addParameter("targetZ", this.targetZ);
+        addParameter("targetY", this.targetY);
+        addParameter("indexTip", this.indexTip);
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        float y = this.targetY.getValuef();
+        float z = this.targetZ.getValuef();
+
+        int color = this.teColors.get(0).getColor();
+
+        for (TEPanelModel panel : this.model.panelsById.values()) {
+            for (LXPoint point : panel.points) {
+                boolean isCloseToZ = Math.abs(Math.floor(point.zn * 100) - z) < 5;
+                boolean isCloseToY = Math.abs(Math.floor(point.yn * 100 * 2) - y) < 10;
+                if (isCloseToZ && isCloseToY) {
+                    colors[point.index] = color;
+                } else {
+                    colors[point.index] = LXColor.BLACK;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter p) {
+        super.onParameterChanged(p);
+        if (p == this.indexTip) {
+            String[] points = ((StringParameter) p).getString().split(",");
+            float yFromPoint = Float.parseFloat(points[1]);
+            float zFromPoint = Float.parseFloat(points[0]);
+
+            this.targetY.setValue(yFromPoint);
+            this.targetZ.setValue(zFromPoint);
+        }
+    }
+}


### PR DESCRIPTION
Added a POC class to show the coordinates received by gesture input. 

A 3rd party application can be configured to send OSC messages. (ex `/lx/mixer/channel/1/pattern/1/fuel 51`)

![firehands](https://user-images.githubusercontent.com/527525/159396656-d95a72b7-c27e-4dca-817e-b8cc2a591775.gif)


An LX Studio instance must turn on the OSC Listener. It can be configured in the top right of the UI (image below) or using the SDK: 

```java
lx.engine.osc.logInput.setValue(true);
lx.engine.osc.receiveActive.setValue(true);
```

![image](https://user-images.githubusercontent.com/527525/159396831-9fe77f0b-67b9-4c75-b912-b3cc9cb3bd37.png)
